### PR TITLE
Collection crashes on first launch with blank style; make style "a" instead

### DIFF
--- a/mod.js
+++ b/mod.js
@@ -113,7 +113,7 @@ module.exports = {
       styles: [
         {
           // Set collide & act 7 style manually
-          body: api.store.get("collideAct7Style", "") // mod must be restarted twice to update
+          body: api.store.get("collideAct7Style", "a") // mod must be restarted twice to update; fallback is "a" since "" crashes TUHC
         },
         {
           source: "./povmap.css"


### PR DESCRIPTION
When installing the mod on a fresh install of the collection, an error occurs: Styles must define some sort of body!

Due to the somewhat hacky way that Collide and Act 7 are handled, we need to cache the CollideAct7 style rules.  The collection needs the style before it gives POV Cam the chance to compute it, so on the first start, we gave a blank style: "", which will be quickly overwritten for the next launch.  However, this blank style prevents the collection from starting, until the user quits and tries again.

This change just makes it so the placeholder style is "a" instead of "", which the collection is happy with.